### PR TITLE
fix: add public eslint-config-invision package

### DIFF
--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -2,10 +2,9 @@
   type: parallel
   encrypted_dockercfg_path: codeship-dockercfg.encrypted
   steps:
-    # TODO: disable eslint until eslint-config-invision package is public
-    # - name: Run lint tests
-    #   service: test
-    #   command: lint
+    - name: Run lint tests
+      service: test
+      command: lint
     - name: Run unit tests
       service: test
       command: test-unit

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "chai": "3.5.0",
+    "eslint-config-invision": "3.0.0",
     "mocha": "2.4.5",
     "sinon": "1.17.3",
     "sinon-chai": "2.8.0"


### PR DESCRIPTION
Adds in ESLint now that we've got the package public. This will probably fail the codeship step due to some lint errors that need resolving.