### PR TITLE
now by default will not removed resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ The following environment variables are used by this service.
 | `IS_ROLLBACK` | A boolean flag that is passed in the available payload post | yes | `false` |
 | `DIFF` | Will show a diff | yes | `false` |
 | `FORCE` | Will push all changes even if there are no differences | yes | `false` |
+| `DELETE_RESOURCES` | Delete resources that are deployed to cluster but no manifest found locally | yes | `true` |
 | `AVAILABLE_ENABLED` | Will check if deployed service is available, but will only affect if deployment is considered successful or not if --available-required is also enabled | yes | `false` |
 | `AVAILABLE_HEALTH_CHECK` | Will monitor for issues during the deployment | yes | `true` |
 | `AVAILABLE_HEALTH_CHECK_GRACE_PERIOD` | The amount of time in seconds that the health check will wait for a deployment to self-heal before triggering a failure | yes | `10` |

--- a/src/deployer
+++ b/src/deployer
@@ -25,6 +25,7 @@ program
 	.option("--is-rollback <boolean>", "A boolean flag that is passed in the available payload post", parseBoolean, parseBoolean(process.env.IS_ROLLBACK))
 	.option("--diff <boolean>", "Will show a diff", parseBoolean, parseBoolean(process.env.DIFF))
 	.option("--force <boolean>", "Will push all changes even if there are no differences", parseBoolean, parseBoolean(process.env.FORCE))
+	.option("--deleteResources <boolean>", "Delete manifest resources that were not generated", parseBoolean, parseBoolean(process.env.DELETE_RESOURCES))
 	.option("--available-enabled <boolean>", "Will check if deployed service is available, but will only affect if deployment is considered successful or not if --available-required is also enabled", parseBoolean, parseBoolean(process.env.AVAILABLE_ENABLED))
 	.option("--available-health-check <boolean>", "Will monitor for issues during the deployment", parseBoolean, parseBoolean(process.env.AVAILABLE_HEALTH_CHECK))
 	.option("--available-health-check-grace-period <int>", "The amount of time in seconds that the health check will wait for a deployment to self-heal before triggering a failure", parseInt, parseInt(process.env.AVAILABLE_HEALTH_CHECK_GRACE_PERIOD))
@@ -54,6 +55,7 @@ const options = {
 	isRollback: program.isRollback,
 	diff: program.diff,
 	force: program.force,
+	deleteResources: program.deleteResources,
 	available: {
 		enabled: program.availableEnabled,
 		healthCheck: program.availableHealthCheck,

--- a/src/lib/deployer.js
+++ b/src/lib/deployer.js
@@ -22,6 +22,7 @@ class Deployer extends EventEmitter {
 			isRollback: false,
 			diff: false,
 			force: false,
+			deleteResources: true,
 			available: {
 				enabled: false,
 				webhooks: [],
@@ -123,6 +124,7 @@ class Deployer extends EventEmitter {
 							available: self.options.available,
 							diff: self.options.diff,
 							force: self.options.force,
+							deleteResources: self.options.deleteResources,
 							kubectl: kubectl
 						});
 						manifests.on("status", (status) => {


### PR DESCRIPTION
# What

Now by default will not removed resources that are deployed but do not have local manifests, also will skip entire clusters if no generated files are found. This is a change in behavior then previous version which would sync clusters (including deleting deployed resources if not found locally).  This is still available by setting the DELETE_RESOURCES env.