### PR TITLE
feat: distinguish timeout errors from all other errors and pass this in the webhook payload.

### DIFF
--- a/src/lib/manifests.js
+++ b/src/lib/manifests.js
@@ -319,6 +319,7 @@ class Manifests extends EventEmitter {
 																		this.emit("error", err);
 																		this.emit("status", {
 																			cluster: this.options.cluster.metadata.name,
+																			reason: (err.name === "TimeoutError" ? "timeout" : "other"),
 																			name: manifestName,
 																			kind: manifest.kind,
 																			phase: "COMPLETED",

--- a/src/lib/manifests.js
+++ b/src/lib/manifests.js
@@ -319,7 +319,7 @@ class Manifests extends EventEmitter {
 																		this.emit("error", err);
 																		this.emit("status", {
 																			cluster: this.options.cluster.metadata.name,
-																			reason: (err.name === "TimeoutError" ? "timeout" : "other"),
+																			reason: (err.name || "other"),
 																			name: manifestName,
 																			kind: manifest.kind,
 																			phase: "COMPLETED",

--- a/src/lib/status.js
+++ b/src/lib/status.js
@@ -5,6 +5,7 @@ const Promise = require("bluebird");
 const EventEmitter = require("events").EventEmitter;
 const KeepAlive = require("./keep-alive");
 const HealthCheck = require("./health-check");
+const TimeoutError = require("../util/timeout-error");
 const supportedTypes = [
 	"deployment",
 	"ingress",
@@ -180,7 +181,7 @@ class Status extends EventEmitter {
 				if (keepAlive) {
 					keepAlive.stop();
 				}
-				reject(new Error("Timeout waiting for " + resource + ":" + name));
+				reject(new TimeoutError("Timeout waiting for " + resource + ":" + name));
 			}, parseInt(this.options.timeout) * 1000);
 		});
 	}

--- a/src/lib/webhook.js
+++ b/src/lib/webhook.js
@@ -127,7 +127,7 @@ class Webhook extends EventEmitter {
 				const promises = [];
 				_.each(this.manifests, (manifestStatus) => {
 					const name = this.getManifestName(manifestStatus);
-					promises.push(this.send(name, manifestStatus.phase, manifestStatus.status));
+					promises.push(this.send(name, manifestStatus.phase, manifestStatus.status, manifestStatus.reason));
 				});
 				Promise
 					.all(promises)
@@ -143,6 +143,7 @@ class Webhook extends EventEmitter {
 			if (!this.manifests[name]) {
 				// Always send the first status we receive for a manifest
 				this.manifests[name] = status;
+
 				this.send(name, status.phase, status.status, status.reason);
 			} else if (this.manifests[name].status !== "FAILURE") {
 				// If the status is failure for any cluster, we consider the deployment as a whole a failure, so keep failure status

--- a/src/lib/webhook.js
+++ b/src/lib/webhook.js
@@ -35,7 +35,7 @@ class Webhook extends EventEmitter {
 		});
 	}
 
-	send(name, phase, status) {
+	send(name, phase, status, reason) {
 		const payload = {
 			// TODO: dynamic name for payload?
 			name: "kubernetes-deploy",
@@ -47,6 +47,7 @@ class Webhook extends EventEmitter {
 				queue_id: undefined,
 				phase: phase,
 				status: status,
+				reason: reason,
 				url: undefined,
 				scm: {
 					url: undefined,
@@ -142,7 +143,7 @@ class Webhook extends EventEmitter {
 			if (!this.manifests[name]) {
 				// Always send the first status we receive for a manifest
 				this.manifests[name] = status;
-				this.send(name, status.phase, status.status);
+				this.send(name, status.phase, status.status, status.reason);
 			} else if (this.manifests[name].status !== "FAILURE") {
 				// If the status is failure for any cluster, we consider the deployment as a whole a failure, so keep failure status
 				this.manifests[name] = status;

--- a/src/util/timeout-error.js
+++ b/src/util/timeout-error.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/*
+ * Allows to explicitly detect a timeout error by extending the base Error class.
+ */
+class TimeoutError extends Error {
+	constructor(message) {
+		super(message);
+		this.message = message;
+		this.name = "TimeoutError";
+	}
+}
+
+module.exports = TimeoutError;

--- a/test/functional/functional.spec.js
+++ b/test/functional/functional.spec.js
@@ -44,6 +44,18 @@ describe("Functional", function() {
 			});
 		});
 
+		it("should trigger a TimeoutError after exceeding AVAILABLE_TIMEOUT", function(done) {
+			process.env.CONFIGS = "/test/functional/clusters/configs/example-kubeconfig.yaml";
+			process.env.AVAILABLE_TIMEOUT = 1;
+
+			exec("./src/deployer", function(error, stdout, stderr) {
+				expect(stdout).not.to.be.empty;
+				expect(stdout).to.contain("Sending payload to http://example.com/test/auth-svc for auth-svc with status COMPLETED/FAILURE");
+				expect(stdout).to.match(/.*TimeoutError*/);
+				done();
+			});
+		});
+
 		afterEach(function() {
 			var kubectl = new Kubectl({
 				kubeconfig: process.env.CONFIGS

--- a/test/unit/util/timeout-error.spec.js
+++ b/test/unit/util/timeout-error.spec.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const expect = require("chai").expect;
+const TimeoutError = require("../../../src/util/timeout-error");
+
+describe("TimeoutError", () => {
+	var error, message;
+
+	beforeEach(function() {
+		message = "The deployment timed out.";
+		error = new TimeoutError(message);
+	});
+
+	it("should have the correct name", () => {
+		expect(error.name).to.equal("TimeoutError");
+	});
+
+	it("should be an instance of the TimeoutError type", () => {
+		expect(error).to.be.instanceof(TimeoutError);
+	});
+
+	it("should be an instance of the Error type", () => {
+		expect(error).to.be.instanceof(Error);
+	});
+
+	it("should return the original message", () => {
+		expect(error.message).to.equal(message);
+	});
+});


### PR DESCRIPTION
## What
Adds a custom `TimeoutError` type, which fires when the timing out waiting for the manifests. This status is passed on in the body of the webhook payload as `reason: timeout/other`.

## Testing
* `npm run test-unit`
* `./test-functional`