### PR TITLE
Adds the ability to save generated manifests to S3 bucket. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ Currently we only properly support the following types to be used as dependencie
 - `Secret`
 - `Service`
 
+### Manifest backup
+
+With `BACKUP_ENABLED` set to true each manifest will be backed up to the specified S3 bucket with the path `/AWS_BUCKET/cluster-name/manifest` _after_ the manifest has been deployed. By default files can be backed up as `yaml` or `json` format - `yaml` is the default.
+
 ## Expected environment variables
 
 The following environment variables are used by this service.
@@ -166,6 +170,11 @@ The following environment variables are used by this service.
 | `GITHUB_AUTH_TOKEN` | Your github token to the repo we are deploying (used to retrieve additional info on the commit) | yes | *empty* |
 | `GITHUB_USER` | The github user that the repo belongs to | yes | *empty* |
 | `GITHUB_REPO` | The github repo name | yes | *empty* |
+| `BACKUP_ENABLED` | Enable Backups to AWS S3 | no | false |
+| `SAVE_FORMAT` | Format to save backup manifest as (json | yaml) | no | yaml |
+| `AWS_BUCKET` | AWS s3 bucket name to save to | yes | *empty* |
+| `AWS_ACCESS_KEY_ID` | AWS User key to use | yes | *empty* |
+| `AWS_SECRET_ACCESS_KEY` | AWS User Secret to use | yes | *empty* |
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "request-promise": "3.0.0",
     "rimraf": "2.5.3",
     "traverse": "0.6.6",
-    "uuid": "2.0.2"
+    "uuid": "2.0.2",
+    "aws-sdk": "2.7.7"
   },
   "devDependencies": {
     "chai": "3.5.0",

--- a/src/lib/backup.js
+++ b/src/lib/backup.js
@@ -34,7 +34,7 @@ const save = function( clusterName, manifest ) {
 		if (!clusterName || !manifest) { return reject("Cluster or Manifest not supplied") }
 
 		// If disabled skip processing
-		if (!enabled) { return resolve(); }
+		if (enabled === "false" || enabled === false) { return resolve(); }
 
 		// Create the s3 object if not already
 		if ( !s3 ) { s3 = new AWS.S3(); }

--- a/src/lib/backup.js
+++ b/src/lib/backup.js
@@ -1,0 +1,65 @@
+"use strict";
+
+const AWS = require("aws-sdk");
+const Promise = require("bluebird");
+const bucket = process.env.AWS_BUCKET;
+const enabled = (process.env.BACKUP_ENABLED || false);
+const saveFormat = ( process.env.SAVE_FORMAT === "json" ? "json" : "yaml" );
+const yaml = require("js-yaml");
+
+
+// validate required ENVs if enabled
+if ( enabled && ( !process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_ACCESS_KEY || !bucket ) ) {
+	throw new Error("Missing required ENV's, validate AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_BUCKET exist");
+}
+
+let s3;
+
+/**
+ * Backs up the provided manifest to a s3 bucket.
+ * Path is <BUCKET>/<clusterName>/<manifest-name>
+ * Requires AWS Credentials as EV's:
+ * AWS_ACCESS_KEY_ID
+ * AWS_SECRET_ACCESS_KEY
+ *   as well as the AWS_BUCKET
+ *
+ * @param  {[type]} clusterName [description]
+ * @param  {[type]} manifest    [description]
+ * @return {[type]}             [description]
+ */
+const save = function( clusterName, manifest ) {
+
+	return new Promise((resolve, reject) => {
+
+		if (!clusterName || !manifest) { return reject("Cluster or Manifest not supplied") }
+
+		// If disabled skip processing
+		if (!enabled) { return resolve(); }
+
+		// Create the s3 object if not already
+		if ( !s3 ) { s3 = new AWS.S3(); }
+
+		const name = manifest.metadata.name;
+		let s3Request = {
+			Bucket: bucket,
+			Key: `${clusterName}/${manifest.metadata.name}.${saveFormat}`,
+			ServerSideEncryption: "AES256"
+		};
+
+		if (saveFormat === "yaml") {
+			// convert to YAML before save
+			 s3Request.Body = yaml.safeDump(manifest, {});
+		} else {
+			s3Request.Body = manifest;
+		}
+		// Save file to s3 bucket.
+		s3.putObject(s3Request, function(err, data) {
+			if (err) {
+				return reject(err);
+			}
+			return resolve(data);
+		});
+	});
+}
+
+module.exports = save;

--- a/src/lib/manifests.js
+++ b/src/lib/manifests.js
@@ -335,8 +335,18 @@ class Manifests extends EventEmitter {
 																}
 															}
 														}).then( () => {
-															this.emit("info", "Calling backup if enabled.");
-															return backup(this.options.cluster.metadata.name, manifest);
+															this.emit("info", "Calling backup");
+															return backup(this.options.cluster.metadata.name, manifest)
+																.then( (data) => {
+																	if (!data) {
+																		this.emit("info", `No Backup of ${manifest.metadata.name}`);
+																	} else {
+																		this.emit("info", "backup result " + JSON.stringify(data));
+																	}
+																})
+																.catch( (err) => {
+																	this.emit("warning", `Warning: (${(err ? err.message : "undefined")}) Backing up ${manifest.metadata.name} to ${this.options.cluster.metadata.name}`);
+																});
 														})
 														.catch((err) => {
 															this.emit("error", "Error running kubectl." + method.toLowerCase() + "('" + tmpApplyingConfigurationPath + "') " + err);

--- a/src/lib/manifests.js
+++ b/src/lib/manifests.js
@@ -17,6 +17,7 @@ const writeFileAsync = Promise.promisify(fs.writeFile);
 const uuid = require("uuid");
 const mkdirp = Promise.promisify(require("mkdirp"));
 const rimraf = Promise.promisify(require("rimraf"));
+const backup = require("./backup");
 const supportedTypes = [
 	"deployment",
 	"ingress",
@@ -333,6 +334,9 @@ class Manifests extends EventEmitter {
 																	return availablePromise;
 																}
 															}
+														}).then( () => {
+															this.emit("info", "Calling backup if enabled.");
+															return backup(this.options.cluster.metadata.name, manifest);
 														})
 														.catch((err) => {
 															this.emit("error", "Error running kubectl." + method.toLowerCase() + "('" + tmpApplyingConfigurationPath + "') " + err);


### PR DESCRIPTION
# What

Adds the ability to save the generated manifest to an S3 bucket for backup. This will allow a quick rebuild of any cluster/namespaces. Note only changed manifests are backed up. For a full backup a complete set of generated manifests should be seeded initially.

This can be enabled via an ENV and is **_off_** by default.

Note: The S3 bucket has versioning turned on. 