### PR TITLE
Only query clusters if we have manifests to process

### DIFF
--- a/src/lib/manifests.js
+++ b/src/lib/manifests.js
@@ -235,7 +235,7 @@ class Manifests extends EventEmitter {
 					// There are no files to process, skip cluster to prevent needless querying of resources on the cluster
 					if (Array.isArray(this.manifestFiles) && this.manifestFiles.length === 0) {
 						this.emit("debug", "No cluster files to processs, skipping " + this.options.cluster.metadata.name);
-						return Promise.resolve(true);
+						return true;
 					}
 					// There are files to process, so let's get the list of current resources on the cluster
 					return this


### PR DESCRIPTION
# What

- There is no need to query the resources from a cluster if we do not have any manifests to process for that cluster
- I also handled some lint errors shown in my editor for the `manifest.js` file (basically functions that should have explicitly had a return)