### PR TITLE
Only query namespaces if needed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.js]
+charset = utf-8
+indent_style = tab
+indent_size = 2
+trim_trailing_whitespace = true


### PR DESCRIPTION
# What

- We first query clusters for namespaces so that we can create those namespaces if they don't exist yet
- This fixes it so that if there are no namespace files defined, then it won't bother querying clusters for the list of namespaces they currently have
- I also added an `.editorconfig` file by popular demand