### PR TITLE
Added progress event

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ deployer.on("fatal", function(message) {
 deployer.on("status", function(status) {
 	console.log(status);
 });
+deployer.on("progress", function(progress) {
+	console.log(progress);
+});
 
 deployer
 	.deploy("/configs/**/kubeconfig", "/manifests", "/namespaces")
@@ -82,6 +85,35 @@ deployer
 ```
 
 Note this method requires node and was tested on version `5.5.0`.
+
+## Progress
+
+The progress event emits whenever a cluster was successfully deployed to or failed deploying. It will tell you how many clusters are left, how many had issues being deployed to and what these clusters were. This is what the object looks like. Information is purposely made redundant for easier logging where needed.
+
+```json
+{
+  "percent": 0.5,
+  "clusters": {
+    "total": 4,
+    "completed": 2,
+    "found": [
+      "cluster-1",
+      "cluster-2",
+      "cluster-3",
+      "cluster-4"
+    ],
+    "remaining": [
+      "cluster-2",
+      "cluster-3"
+    ],
+    "successful": [
+      "cluster-1",
+      "cluster-2"
+    ],
+    "failed": []
+  }
+}
+```
 
 ## Namespaces
 

--- a/src/lib/progress.js
+++ b/src/lib/progress.js
@@ -1,0 +1,59 @@
+"use strict";
+
+const EventEmitter = require("events");
+const _ = require("lodash");
+
+class Progress extends EventEmitter {
+	constructor(options) {
+		super();
+		this._status = {
+			clusters: {
+				total: 0,
+				completed: 0,
+				found: [],
+				remaining: [],
+				successful: [],
+				failed: []
+			}
+		};
+	}
+
+	// Update and emit the current progress
+	status() {
+		return {
+			percent: this._status.clusters.completed / this._status.clusters.total,
+			clusters: this._status.clusters
+		};
+	}
+
+	add(cluster) {
+		if (typeof cluster != "string") {
+			throw new Error(`Cluster given to progress has to be string: ${cluster}`);
+		}
+		this._status.clusters.total++;
+		this._status.clusters.found.push(cluster);
+		this._status.clusters.remaining.push(cluster);
+	}
+
+	success(cluster) {
+		if (typeof cluster != "string") {
+			throw new Error(`Cluster given to progress has to be string: ${cluster}`);
+		}
+		this._status.clusters.completed++;
+		this._status.clusters.successful.push(cluster);
+		this._status.clusters.remaining = _.without(this._status.clusters.remaining, cluster);
+		this.emit("progress", this.status());
+	}
+
+	fail(cluster) {
+		if (typeof cluster != "string") {
+			throw new Error(`Cluster given to progress has to be string: ${cluster}`);
+		}
+		this._status.clusters.completed++;
+		this._status.clusters.failed.push(cluster);
+		this._status.clusters.remaining = _.without(this._status.clusters.remaining, cluster);
+		this.emit("progress", this.status());
+	}
+}
+
+module.exports = Progress;

--- a/src/lib/webhook.js
+++ b/src/lib/webhook.js
@@ -36,7 +36,7 @@ class Webhook extends EventEmitter {
 		});
 	}
 
-	send(name, phase, status, reason) {
+	send(name, phase, status, reason, progress) {
 		const payload = {
 			// TODO: dynamic name for payload?
 			name: "kubernetes-deploy",
@@ -49,6 +49,7 @@ class Webhook extends EventEmitter {
 				phase: phase,
 				status: status,
 				reason: reason,
+				progress: progress,
 				url: undefined,
 				scm: {
 					url: undefined,
@@ -128,7 +129,7 @@ class Webhook extends EventEmitter {
 				const promises = [];
 				_.each(this.manifests, (manifestStatus) => {
 					const name = this.getManifestName(manifestStatus);
-					promises.push(this.send(name, manifestStatus.phase, manifestStatus.status, manifestStatus.reason));
+					promises.push(this.send(name, manifestStatus.phase, manifestStatus.status, manifestStatus.reason, status.progress));
 				});
 				Promise
 					.all(promises)
@@ -145,7 +146,7 @@ class Webhook extends EventEmitter {
 				// Always send the first status we receive for a manifest
 				this.manifests[name] = status;
 
-				this.send(name, status.phase, status.status, status.reason);
+				this.send(name, status.phase, status.status, status.reason, status.progress);
 			} else if (this.manifests[name].status !== "FAILURE") {
 				// If the status is failure for any cluster, we consider the deployment as a whole a failure, so keep failure status
 				this.manifests[name] = status;

--- a/test/functional/functional.spec.js
+++ b/test/functional/functional.spec.js
@@ -34,7 +34,7 @@ describe("Functional", function() {
 					expect(error).to.be.a("null", stdout);
 					expect(stderr).to.be.empty;
 					expect(stdout).not.to.be.empty;
-					expect(stdout).to.contain("Generating tmp directory:", stdout);
+					expect(stdout).to.contain("Generating tmp directory:");
 					expect(stdout).to.contain("example-cluster - Getting list of namespaces");
 					expect(stdout).to.contain("example-cluster - Create example namespace");
 					expect(stdout).to.contain("example-cluster - namespace \"example\" created");

--- a/test/unit/lib/progress.spec.js
+++ b/test/unit/lib/progress.spec.js
@@ -1,0 +1,103 @@
+"use strict"
+
+const chai = require("chai");
+const expect = chai.expect;
+const Progress = require("../../../src/lib/progress");
+
+describe("Progress", () => {
+	describe("Constructor", () => {
+		it("should construct without error", () => {
+			const progress = new Progress();
+			expect(progress).to.exist;
+		});
+	});
+	describe("Add", () => {
+		it("should error when non-string", () => {
+			const progress = new Progress();
+			var fn = function() {
+				progress.add({});
+			};
+			expect(fn).to.throw(Error);
+		});
+		it("should add cluster", () => {
+			const progress = new Progress();
+			progress.add("test-cluster1");
+			progress.add("test-cluster2");
+			progress.add("test-cluster3");
+			progress.add("test-cluster4");
+			expect(progress.status().clusters.total).to.equal(4);
+			expect(progress.status().clusters.found).to.have.length(4);
+			expect(progress.status().clusters.remaining).to.have.length(4);
+			expect(progress.status().clusters.completed).to.equal(0);
+			expect(progress.status().clusters.successful).to.have.length(0);
+			expect(progress.status().clusters.failed).to.have.length(0);
+			expect(progress.status().percent).to.equal(0);
+		});
+
+		describe("Success", () => {
+			let progress;
+			beforeEach(() => {
+				progress = new Progress();
+				progress.add("test-cluster1");
+				progress.add("test-cluster2");
+				progress.add("test-cluster3");
+				progress.add("test-cluster4");
+			});
+			it("should error when non-string", () => {
+				var fn = function() {
+					progress.success({});
+				};
+				expect(fn).to.throw(Error);
+			});
+			it("should increment status", () => {
+				progress.success("test-cluster1");
+				expect(progress.status().clusters.total).to.equal(4);
+				expect(progress.status().clusters.found).to.have.length(4);
+				expect(progress.status().clusters.remaining).to.have.length(3);
+				expect(progress.status().clusters.completed).to.equal(1);
+				expect(progress.status().clusters.successful).to.have.length(1);
+				expect(progress.status().clusters.failed).to.have.length(0);
+				expect(progress.status().percent).to.equal(0.25);
+			});
+			it("should emit progress", (done) => {
+				progress.on("progress", function() {
+					done();
+				});
+				progress.success("test-cluster1");
+			});
+		});
+
+		describe("Fail", () => {
+			let progress;
+			beforeEach(() => {
+				progress = new Progress();
+				progress.add("test-cluster1");
+				progress.add("test-cluster2");
+				progress.add("test-cluster3");
+				progress.add("test-cluster4");
+			});
+			it("should error when non-string", () => {
+				var fn = function() {
+					progress.fail({});
+				};
+				expect(fn).to.throw(Error);
+			});
+			it("should increment status", () => {
+				progress.fail("test-cluster1");
+				expect(progress.status().clusters.total).to.equal(4);
+				expect(progress.status().clusters.found).to.have.length(4);
+				expect(progress.status().clusters.remaining).to.have.length(3);
+				expect(progress.status().clusters.completed).to.equal(1);
+				expect(progress.status().clusters.successful).to.have.length(0);
+				expect(progress.status().clusters.failed).to.have.length(1);
+				expect(progress.status().percent).to.equal(0.25);
+			});
+			it("should emit progress", (done) => {
+				progress.on("progress", function() {
+					done();
+				});
+				progress.fail("test-cluster1");
+			});
+		});
+	});
+});


### PR DESCRIPTION
# What

- Will now emit a `progress` event whenever a cluster has finished being deployed to (or has failed being deployed to)
- It will include a `progress` property in the webhook it sends which will include current deploy progress, the list of clusters remaining, successful, failed, etc
- If needed later this can be expanded on to provide more granular progress information such as pods remaining

# Testing

- I verified locally using `./test-functional`
- Unit tests were added for the progress class