### PR TITLE
fix: need to pass graceperiod time to healthcheck instanec

### DIFF
--- a/src/lib/manifests.js
+++ b/src/lib/manifests.js
@@ -192,6 +192,7 @@ class Manifests extends EventEmitter {
 
 			var status = new Status({
 				healthCheck: this.options.available.healthCheck,
+				healthCheckGracePeriod: this.options.available.healthCheckGracePeriod,
 				keepAlive: this.options.available.keepAlive,
 				keepAliveInterval: this.options.available.keepAliveInterval,
 				timeout: this.options.available.timeout,


### PR DESCRIPTION
# What

- Was not correctly passing `healthCheckGracePeriod` down to the Healthcheck instance which means it always just defaulted to the 10 second grace period