### PR TITLE
False positive healthcheck

### DIFF
--- a/src/lib/health-check.js
+++ b/src/lib/health-check.js
@@ -24,7 +24,11 @@ class HealthCheck extends EventEmitter {
 	constructor(kubectl, gracePeriod, since) {
 		super();
 		this.events = kubectl.events(since);
-		this.errorTimeoutId = null;
+		this.error = {
+			timeoutId: null,
+			involvedObjectName: null
+		};
+		this.beingKilled = [];
 		this.gracePeriod = (typeof gracePeriod === "undefined") ? 10 * 1000 : gracePeriod * 1000; // 10 seconds
 	}
 
@@ -42,6 +46,22 @@ class HealthCheck extends EventEmitter {
 				return;
 			}
 
+			// Ignore events for involved objects that are being killed
+			if (this.beingKilled.indexOf(event.involvedObject.name) >= 0) {
+				if (this.error.involvedObjectName == event.involvedObject.name) {
+					this.emit("debug", "Clearing healthcheck timeout because " + event.involvedObject.name + " is being killed");
+					clearTimeout(this.error.timeoutId);
+				}
+				return;
+			}
+
+			// If we encounter a Killing event for any involvedObject we should not care about it's health
+			// A "Killing" event is of type "Normal" and means that a pod is purposefully being killed
+			if (event.reason == "Killing") {
+				this.beingKilled.push(event.involvedObject.name);
+				return;
+			}
+
 			// Skip reasons that are excluded from checking
 			if (excludeReasons.indexOf(event.reason) >= 0) {
 				return;
@@ -52,7 +72,8 @@ class HealthCheck extends EventEmitter {
 				if (this.error.timeoutId === null) {
 					// Emit error unless stop is called before grace period expires
 					this.emit("debug", "Healthcheck detected " + event.reason + " error for " + event.involvedObject.name + ", waiting grace period " + this.gracePeriod + "ms before emitting");
-					this.errorTimeoutId = setTimeout(() => {
+					this.error.involvedObjectName = event.involvedObject.name;
+					this.error.timeoutId = setTimeout(() => {
 						this.emit("debug", "Healthcheck grace period of " + this.gracePeriod + "ms expired");
 						this.emit("error", new EventError(event));
 					}, this.gracePeriod);
@@ -65,7 +86,7 @@ class HealthCheck extends EventEmitter {
 	stop() {
 		this.emit("debug", "Stopping healthcheck watcher");
 		this.events.stop();
-		if (this.errorTimeoutId !== null) {
+		if (this.error.timeoutId !== null) {
 			this.emit("debug", "Clearing healthcheck timeout");
 			clearTimeout(this.errorTimeoutId);
 		}

--- a/src/lib/health-check.js
+++ b/src/lib/health-check.js
@@ -51,6 +51,10 @@ class HealthCheck extends EventEmitter {
 				if (this.error.involvedObjectName == event.involvedObject.name) {
 					this.emit("debug", "Clearing healthcheck timeout because " + event.involvedObject.name + " is being killed");
 					clearTimeout(this.error.timeoutId);
+					this.error = {
+						timeoutId: null,
+						involvedObject: null
+					};
 				}
 				return;
 			}
@@ -89,6 +93,10 @@ class HealthCheck extends EventEmitter {
 		if (this.error.timeoutId !== null) {
 			this.emit("debug", "Clearing healthcheck timeout");
 			clearTimeout(this.errorTimeoutId);
+			this.error = {
+				timeoutId: null,
+				involvedObject: null
+			};
 		}
 		this.removeAllListeners();
 	}


### PR DESCRIPTION
# What

- We noticed false positives because services could generate "unhealthy" reason events when being terminated
- We also noticed services can often have "unhealthy" reason events when first being deployed but the rollout doesn't finish quick enough (too long grace period required). For this reason it's just easier to ignore "unhealthy" reason events completely and only worry about other types of events that are more guaranteed to be a problem (such as CrashLoopBackOff). It may slow down the error detection but it will cause far fewer false positives which is more important
- Also added in a check for objects being killed and events for these objects will be ignored because these are the objects purposefully being shutdown during a deployment and we don't much care for bad events on these objects while they are being terminated