### PR TITLE
fix: healthcheck threshold was not working correctly

### DIFF
--- a/src/lib/kubectl.js
+++ b/src/lib/kubectl.js
@@ -77,8 +77,8 @@ class KubectlEventWatcher extends EventEmitter {
 						_.each(result.items, (event) => {
 							// All events should have UIDs as described by kubernetes metadata spec (but just being safe)
 							if (_.has(event, ["metadata", "uid"])) {
-								if (this._previousEvents[event.metadata.uid]) {
-									// We already emitted this event, so do nothing
+								if (this._previousEvents[event.metadata.uid] && this._previousEvents[event.metadata.uid].count == event.count) {
+									// We already emitted this event and the count has not changed, so do nothing
 								} else if (_.has(event, ["firstTimestamp"]) && new Date(event.firstTimestamp).getTime() < this.since) {
 									// Ignore events that first occurred before since date
 								} else {

--- a/src/lib/status.js
+++ b/src/lib/status.js
@@ -70,6 +70,9 @@ class Status extends EventEmitter {
 			// need to make sure the healthcheck observes all events for the resource
 			const since = (differences) ? null : -1;
 			const healthCheck = new HealthCheck(this.kubectl, this.options.healthCheckGracePeriod, since, this.options.healthCheckThreshold);
+			healthCheck.on("info", (err) => {
+				this.emit("info", err);
+			});
 			healthCheck.on("error", (err) => {
 				this.emit("_error", err);
 			});

--- a/test/functional/clusters/configs/badimage-kubeconfig.yaml
+++ b/test/functional/clusters/configs/badimage-kubeconfig.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Config
+metadata:
+  name: badimage-cluster
+clusters:
+- name: badimage-cluster
+  cluster:
+    insecure-skip-tls-verify: true
+    server: http://127.0.0.1:8080
+contexts:
+- name: badimage-cluster-context
+  context:
+    cluster: badimage-cluster
+    namespace: badimage
+    user: badimage-cluster-admin
+users:
+- name: badimage-cluster-admin
+  user:
+    token: badimage-cluster-admin-token
+current-context: badimage-cluster-context

--- a/test/functional/clusters/manifests/badimage-cluster/badimage-deployment.yaml
+++ b/test/functional/clusters/manifests/badimage-cluster/badimage-deployment.yaml
@@ -1,0 +1,18 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: badimage-deployment
+  labels:
+    app: test
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: badimage-pod
+    spec:
+      containers:
+        - name: nginx1-con
+          image: oveits/docker-nginx-busybox:does-not-exist
+          ports:
+            - containerPort: 80

--- a/test/functional/clusters/namespaces/badimage-cluster/badimage-namespace.yaml
+++ b/test/functional/clusters/namespaces/badimage-cluster/badimage-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: badimage


### PR DESCRIPTION
# What

- The threshold checking wasn't working because our event watcher never emitted events of the same name
- Fixed this by emitting events of the same name only if the count had increased
- I improved on the logging messaging as well

# Testing

- I added a functional test to verify health check detection
- Run `./test-functional` (has to be used with Docker Machine)