### PR TITLE
feat: include the involved object in the event error thrown

### DIFF
--- a/src/util/event-error.js
+++ b/src/util/event-error.js
@@ -5,7 +5,10 @@
  */
 class EventError extends Error {
 	constructor(event) {
-		const message = event.message || "Unknown kubernetes event error";
+		let message = event.message || "Unknown kubernetes event error";
+		if (event.involvedObject && event.involvedObject.name) {
+			message = message + " for " + event.involvedObject.name;
+		}
 		super(message);
 		this.message = message;
 		this.name = "EventError";

--- a/test/functional/functional.spec.js
+++ b/test/functional/functional.spec.js
@@ -121,7 +121,7 @@ describe("Functional", function() {
 					expect(stdout).to.match(/Healthcheck grace period of \d+ms expired/);
 					expect(stdout).to.contain("Stopping healthcheck watcher");
 					expect(stdout).to.contain("Clearing healthcheck timeout");
-					expect(stdout).to.contain("EventError: ");
+					expect(stdout).to.match(/EventError: [\w\s"\/\-:(){}\\]+ for badimage-deployment-/);
 					expect(stdout).to.contain("Sending payload to http://example.com/test/badimage-deployment for badimage-deployment with status STARTED/IN_PROGRESS");
 					expect(stdout).to.contain("Sending payload to http://example.com/test/badimage-deployment for badimage-deployment with status COMPLETED/FAILURE");
 					done();

--- a/test/unit/util/event-error.spec.js
+++ b/test/unit/util/event-error.spec.js
@@ -4,28 +4,57 @@ const expect = require("chai").expect;
 const EventError = require("../../../src/util/event-error");
 
 describe("EventError", () => {
-	var error, event;
+	var err, testEvent;
 
-	beforeEach(function() {
-		event = {
-			message: "Event message here"
-		};
-		error = new EventError(event);
+	describe("and valid event error", () => {
+		beforeEach(function() {
+			testEvent = {
+				involvedObject: {
+					name: "object-name-here"
+				},
+				message: "Event message here"
+			};
+			err = new EventError(testEvent);
+		});
+
+		it("should have the correct name", () => {
+			expect(err.name).to.equal("EventError");
+		});
+
+		it("should be an instance of the EventError type", () => {
+			expect(err).to.be.instanceof(EventError);
+		});
+
+		it("should be an instance of the Error type", () => {
+			expect(err).to.be.instanceof(Error);
+		});
+
+		it("should return the event message", () => {
+			expect(err.message).to.equal(testEvent.message + " for " + testEvent.involvedObject.name);
+		});
 	});
 
-	it("should have the correct name", () => {
-		expect(error.name).to.equal("EventError");
+	describe("and event error missing object", () => {
+		beforeEach(function() {
+			testEvent = {
+				message: "Event message here"
+			};
+			err = new EventError(testEvent);
+		});
+
+		it("should return the event message", () => {
+			expect(err.message).to.equal(testEvent.message);
+		});
 	});
 
-	it("should be an instance of the EventError type", () => {
-		expect(error).to.be.instanceof(EventError);
-	});
+	describe("and event error missing message and object", () => {
+		beforeEach(function() {
+			testEvent = {};
+			err = new EventError(testEvent);
+		});
 
-	it("should be an instance of the Error type", () => {
-		expect(error).to.be.instanceof(Error);
-	});
-
-	it("should return the event message", () => {
-		expect(error.message).to.equal(event.message);
+		it("should return the event message", () => {
+			expect(err.message).to.equal("Unknown kubernetes event error");
+		});
 	});
 });


### PR DESCRIPTION
# What

- We're not really printing the error message multiple times, but rather it's an event error for different involved objects (pods).
- This should fix the perceived error reported in #52 