### PR TITLE
Fix progress

### DIFF
--- a/src/lib/deployer.js
+++ b/src/lib/deployer.js
@@ -181,15 +181,16 @@ class Deployer extends EventEmitter {
 									const msgWithCluster = clusterError(msg);
 									errors.push(msgWithCluster);
 								});
-								return manifests.deploy();
-							})
-							.then((res) => {
-								progress.success(config.metadata.name);
-								return res;
-							})
-							.catch((err) => {
-								progress.fail(config.metadata.name);
-								throw err;
+								return manifests
+									.deploy()
+									.then((res) => {
+										progress.success(config.metadata.name);
+										return res;
+									})
+									.catch((err) => {
+										progress.fail(config.metadata.name);
+										throw err;
+									});
 							}));
 					}));
 				});

--- a/src/lib/progress.js
+++ b/src/lib/progress.js
@@ -20,8 +20,9 @@ class Progress extends EventEmitter {
 
 	// Update and emit the current progress
 	status() {
+		const absolutePercent = this._status.clusters.completed / this._status.clusters.total;
 		return {
-			percent: this._status.clusters.completed / this._status.clusters.total,
+			percent: Math.round(absolutePercent * 1000) / 1000,
 			clusters: this._status.clusters
 		};
 	}


### PR DESCRIPTION
# What

- was incorrectly emitting progress immediately after manifests were sent to the cluster and was not correctly awaiting the health check of the deployed manifests
- added rounding of the percent to avoid really long nummbbeerrrs