### PR TITLE
fix: sending generated manifests to elroy

### DIFF
--- a/src/lib/annotator.js
+++ b/src/lib/annotator.js
@@ -1,0 +1,79 @@
+"use strict";
+
+const _ = require("lodash");
+const crypto = require("crypto");
+
+const mustBeUnique = [
+	"Job",
+	"ScheduledJob",
+	"CronJob"
+];
+
+const Annotations = {
+	get Commit() {
+		return "kit-deployer/commit";
+	},
+	get OriginalName() {
+		return "kit-deployer/original-name";
+	},
+	get LastAppliedConfiguration() {
+		return "kit-deployer/last-applied-configuration";
+	},
+	get LastAppliedConfigurationHash() {
+		return "kit-deployer/last-applied-configuration-sha1";
+	}
+};
+
+class Annotator {
+	constructor(options) {
+		this.options = _.merge({
+			sha: undefined
+		}, options);
+	}
+
+	/**
+	 * Add the required manifest annotations and rename the manifest depending on it's type
+	 *
+	 * @param  {object} manifest     The manifest content
+	 * @return {object}              Contains the annotated manifest and the tmp file path
+	 */
+	annotate(manifest) {
+		// Save configuration we're applying as metadata annotation so we can diff against
+		// on future configuration changes
+		var applyingConfiguration = JSON.stringify(manifest);
+		var applyingConfigurationHash = crypto.createHash("sha1").update(applyingConfiguration, "utf8").digest("hex");
+
+		// To avoid issues with deleting/creating jobs, we instead create a new job with a unique name that is based
+		// on the contents of the manifest
+		var manifestName = manifest.metadata.name;
+		if (mustBeUnique.indexOf(manifest.kind) >= 0) {
+			manifestName = manifest.metadata.name + "-" + applyingConfigurationHash;
+		}
+
+		// Initialize annotations object if it doesn't have one yet
+		if (!manifest.metadata) {
+			manifest.metadata = {};
+		}
+		if (!manifest.metadata.annotations) {
+			manifest.metadata.annotations = {};
+		}
+
+		// Update manifest name before deploying (necessary for manifests we need to give a unique name to like Jobs)
+		manifest.metadata.annotations[Annotations.OriginalName] = manifest.metadata.name;
+		manifest.metadata.name = manifestName;
+
+		// Add our custom annotations before deploying
+		manifest.metadata.annotations[Annotations.LastAppliedConfiguration] = applyingConfiguration;
+		manifest.metadata.annotations[Annotations.LastAppliedConfigurationHash] = applyingConfigurationHash;
+
+		// Add commit annotation to manifest we are creating/updating
+		manifest.metadata.annotations[Annotations.Commit] = JSON.stringify(this.options.sha);
+
+		return manifest;
+	}
+}
+
+module.exports = {
+	Annotator: Annotator,
+	Annotations: Annotations
+};

--- a/test/unit/lib/annotator.spec.js
+++ b/test/unit/lib/annotator.spec.js
@@ -1,0 +1,54 @@
+"use strict";
+
+const _ = require("lodash");
+const chai = require("chai");
+const expect = chai.expect;
+const Annotator = require("../../../src/lib/annotator").Annotator;
+const Annotations = require("../../../src/lib/annotator").Annotations;
+
+describe("Annotator", () => {
+	describe("Create New", () => {
+		let annotator;
+		const originalManifest = {
+			kind: "Deployment",
+			metadata: {
+				name: "manifest-deployment"
+			}
+		};
+		const originalJobManifest = {
+			kind: "Job",
+			metadata: {
+				name: "manifest-job"
+			}
+		};
+		const options = {
+			sha: "123abc"
+		};
+		beforeEach(() => {
+			annotator = new Annotator(options);
+		});
+		it("should be cool with it", () => {
+			expect(annotator.options.sha).to.equal(options.sha);
+		});
+		describe("and calling annotate on deployment", () => {
+			it("should set the expected annotations", () => {
+				const manifest = annotator.annotate(_.cloneDeep(originalManifest));
+				expect(manifest.metadata.name).to.equal(originalManifest.metadata.name);
+				expect(manifest.metadata.annotations[Annotations.OriginalName]).to.equal(originalManifest.metadata.name);
+				expect(manifest.metadata.annotations[Annotations.LastAppliedConfiguration]).to.equal(JSON.stringify(originalManifest));
+				expect(manifest.metadata.annotations[Annotations.LastAppliedConfigurationHash]).to.equal("824c6735b631f957a285da2873d1465d797e4e6f");
+				expect(manifest.metadata.annotations[Annotations.Commit]).to.equal(JSON.stringify(options.sha));
+			});
+		});
+		describe("and calling annotate on job", () => {
+			it("should set the expected annotations", () => {
+				const manifest = annotator.annotate(_.cloneDeep(originalJobManifest));
+				expect(manifest.metadata.name).to.equal(originalJobManifest.metadata.name + "-f94274f6bdc905825d1616fe265bc6d2de773e7c");
+				expect(manifest.metadata.annotations[Annotations.OriginalName]).to.equal(originalJobManifest.metadata.name);
+				expect(manifest.metadata.annotations[Annotations.LastAppliedConfiguration]).to.equal(JSON.stringify(originalJobManifest));
+				expect(manifest.metadata.annotations[Annotations.LastAppliedConfigurationHash]).to.equal("f94274f6bdc905825d1616fe265bc6d2de773e7c");
+				expect(manifest.metadata.annotations[Annotations.Commit]).to.equal(JSON.stringify(options.sha));
+			});
+		});
+	});
+});


### PR DESCRIPTION
# What

- Manifests were not generated in time for when we called elroy and thus they were not sent
- This fixes it so that all the required annotations/renaming of manifests are done upfront
- We added Annotator which helps consolidate the annotation/renaming logic for manifests into a single class