### PR TITLE
Elroy debug

### DIFF
--- a/src/lib/manifests.js
+++ b/src/lib/manifests.js
@@ -234,7 +234,9 @@ class Manifests extends EventEmitter {
 			// Elroy
 			const elroy = new Elroy(_.merge(this.options.elroy, {
 				uuid: this.options.uuid,
-				isRollback: this.options.isRollback
+				isRollback: this.options.isRollback,
+				clusterName: this.options.cluster.metadata.name,
+				resource: this.options.resource
 			}));
 			elroy.on("info", (msg) => {
 				this.emit("info", msg);
@@ -516,7 +518,7 @@ class Manifests extends EventEmitter {
 					// TODO: add dry run check before saving to Elroy
 					// Handles saving generated manifests to the Elroy service
 					kubePromises.push(elroy
-						.start(this.options.cluster.metadata.name, this.options.resource, generatedManifests)
+						.start(generatedManifests)
 						.catch((elroyErr) => {
 							// Ignore errors from elroy (we just log them)
 							this.emit("warn", `Elroy error: ${elroyErr}`);
@@ -553,7 +555,7 @@ class Manifests extends EventEmitter {
 							.then(() => {
 								// Update Elroy that the resource has been deployed successfully
 								return elroy
-									.done(this.options.cluster.metadata.name, this.options.resource)
+									.done()
 									.catch((elroyErr) => {
 										// Ignore errors from elroy (we just log them)
 										this.emit("warn", `Elroy error: ${elroyErr}`);
@@ -574,7 +576,7 @@ class Manifests extends EventEmitter {
 						manifest: this.options.cluster
 					});
 					elroy
-						.fail(this.options.cluster.metadata.name, this.options.resource, err)
+						.fail(err)
 						.catch((elroyErr) => {
 							// Ignore errors from elroy (we just log them)
 							this.emit("warn", `Elroy error: ${elroyErr}`);

--- a/src/lib/manifests.js
+++ b/src/lib/manifests.js
@@ -282,10 +282,10 @@ class Manifests extends EventEmitter {
 						return Promise.resolve();
 					}
 
-					const kubePromises = [];
-					const promiseFuncsWithDependencies = [];
-					const remaining = _.cloneDeep(existing);
-					const generatedManifests = [];
+					var kubePromises = [];
+					var promiseFuncsWithDependencies = [];
+					var remaining = _.cloneDeep(existing);
+					var generatedManifests = [];
 					_.each(this.manifestFiles, (manifestFile) => {
 						var manifest = manifestFile.content;
 

--- a/test/unit/lib/elroy.spec.js
+++ b/test/unit/lib/elroy.spec.js
@@ -50,11 +50,13 @@ describe("Elroy", () => {
 				url: "https://elroy.example.com",
 				secret: "xxxxxx",
 				enabled: true,
-				isRollback: isRollback
+				isRollback: isRollback,
+				clusterName: clusterName,
+				resource: resource
 			});
 			elroy.request = requestMock;
 			return elroy
-				.start(clusterName, resource, manifests)
+				.start(manifests)
 				.then((data) => {
 					expect(data).to.exist;
 					expect(calledWith.method).to.equal("PUT");
@@ -78,11 +80,13 @@ describe("Elroy", () => {
 				url: "https://elroy.example.com",
 				secret: "xxxxxx",
 				enabled: false,
-				isRollback: isRollback
+				isRollback: isRollback,
+				clusterName: clusterName,
+				resource: resource
 			});
 			elroy.request = requestMock;
 			return elroy
-				.start(clusterName, resource, manifests)
+				.start(manifests)
 				.then((data) => {
 					expect(data).to.not.exist;
 				});
@@ -96,11 +100,13 @@ describe("Elroy", () => {
 				url: "https://elroy.example.com",
 				secret: "xxxxxx",
 				enabled: true,
-				isRollback: isRollback
+				isRollback: isRollback,
+				clusterName: clusterName,
+				resource: resource
 			});
 			elroy.request = requestMock;
 			elroy
-				.start(clusterName, resource)
+				.start(manifests)
 				.then(() => {
 					done("Should not be successful when expecting error");
 				})
@@ -118,11 +124,14 @@ describe("Elroy", () => {
 				url: "https://elroy.example.com",
 				secret: "xxxxxx",
 				enabled: true,
-				isRollback: isRollback
+				isRollback: isRollback,
+				clusterName: clusterName,
+				resource: resource
 			});
 			elroy.request = requestMock;
+			elroy._started = true;
 			return elroy
-				.fail(clusterName, resource, error)
+				.fail(error)
 				.then((data) => {
 					expect(data).to.exist;
 					expect(calledWith.method).to.equal("PUT");
@@ -146,11 +155,14 @@ describe("Elroy", () => {
 				url: "https://elroy.example.com",
 				secret: "xxxxxx",
 				enabled: true,
-				isRollback: isRollback
+				isRollback: isRollback,
+				clusterName: clusterName,
+				resource: resource
 			});
 			elroy.request = requestMock;
+			elroy._started = true;
 			return elroy
-				.done(clusterName, resource)
+				.done()
 				.then((data) => {
 					expect(data).to.exist;
 					expect(calledWith.method).to.equal("PUT");


### PR DESCRIPTION
# What

- should not have converted to const as the `remaining` can actually get re-assigned in the current context. Did not want to refactor this out so left it as var
- includes elroy fix so that we don't send requests to elroy if there are no manifests being deployed