### PR TITLE
fix: send to elroy as yaml

### DIFF
--- a/src/lib/elroy.js
+++ b/src/lib/elroy.js
@@ -4,6 +4,7 @@ const _ = require("lodash");
 const Promise = require("bluebird");
 const EventEmitter = require("events");
 const request = require("request-promise");
+const yaml = require("js-yaml");
 
 const Status = {
 	get Success() { return "success"; },
@@ -104,7 +105,14 @@ class Elroy extends EventEmitter {
 			};
 
 			if (manifests) {
-				body.manifests = manifests;
+				// Convert json manifests to yaml before sending
+				var yamlManifests = [];
+				_.each(manifests, (jsonManifest) => {
+					yamlManifests.push(yaml.safeDump(jsonManifest, {
+						sortKeys: true
+					}));
+				});
+				body.manifests = yamlManifests;
 			}
 
 			if (error) {

--- a/test/unit/lib/elroy.spec.js
+++ b/test/unit/lib/elroy.spec.js
@@ -10,6 +10,9 @@ const Type = require("../../../src/lib/elroy").Type;
 describe("Elroy", () => {
 
 	let uuid, clusterName, resource, manifests, isRollback, error, success, calledWith;
+	const yamlManifests = [`metadata:
+  name: service-name
+`];
 	const requestMock = function(opt) {
 		calledWith = opt;
 		return new Promise((resolve, reject) => {
@@ -67,7 +70,7 @@ describe("Elroy", () => {
 						service: resource,
 						type: Type.Promotion,
 						status: Status.InProgress,
-						manifests: manifests
+						manifests: yamlManifests
 					});
 				});
 		});


### PR DESCRIPTION
# What

- elroy expects the manifests to be in `yaml` format