### PR TITLE
fix: diffs were diffing on dynamicly added properties

### DIFF
--- a/src/util/manifest-diff.js
+++ b/src/util/manifest-diff.js
@@ -3,6 +3,7 @@
 const _ = require("lodash");
 const traverse = require("traverse");
 const diff = require("deep-diff");
+const Annotations = require("../lib/annotator").Annotations;
 
 /*
  * Given a manifest object it will search for any Arrays
@@ -34,6 +35,20 @@ function indexArraysByName(manifest) {
 function manifestDiff(previous, latest) {
 	const previousClone = _.cloneDeep(previous);
 	const latestClone = _.cloneDeep(latest);
+
+	// Remove special annotations from latest that are used for diff logic
+	if (_.has(latest, ["metadata"])) {
+		// We remove the name because depending on the type of resource we automatically rename the manifest and this
+		// should not be part of the diff
+		delete latestClone.metadata.name;
+		if (_.has(latest, ["metadata", "annotations"])) {
+			// All these annotations are dynamically generated and thus should not be diffed
+			delete latestClone.metadata.annotations[Annotations.OriginalName];
+			delete latestClone.metadata.annotations[Annotations.LastAppliedConfiguration];
+			delete latestClone.metadata.annotations[Annotations.LastAppliedConfigurationHash];
+			delete latestClone.metadata.annotations[Annotations.Commit];
+		}
+	}
 
 	indexArraysByName(previousClone);
 	indexArraysByName(latestClone);

--- a/test/unit/util/manifest-diff.spec.js
+++ b/test/unit/util/manifest-diff.spec.js
@@ -10,6 +10,30 @@ const scenarios = {
 		latest: {},
 		expected: undefined
 	},
+	"previous object with same properties and latest with special annotations": {
+		previous: {
+			enabled: true,
+			metadata: {
+				annotations: {
+					"keep-me": "okay"
+				}
+			}
+		},
+		latest: {
+			enabled: true,
+			metadata: {
+				name: "should-ignore-name",
+				annotations: {
+					"keep-me": "okay",
+					"kit-deployer/commit": "123abc",
+					"kit-deployer/original-name": "some-og-name",
+					"kit-deployer/last-applied-configuration": "last-applied-here",
+					"kit-deployer/last-applied-configuration-sha1": "sha1-here"
+				}
+			}
+		},
+		expected: undefined
+	},
 	"previous with empty object and latest with new property": {
 		previous: {},
 		latest: {


### PR DESCRIPTION
# What

- when we refactored the annotations we forgot that we have to exclude these dynamically generated properties from the manifest diff or else we'll always have false diffs when deploying