### PR TITLE
fix: diffs for empty annotations and manifest names

### DIFF
--- a/src/util/manifest-diff.js
+++ b/src/util/manifest-diff.js
@@ -37,16 +37,19 @@ function manifestDiff(previous, latest) {
 	const latestClone = _.cloneDeep(latest);
 
 	// Remove special annotations from latest that are used for diff logic
-	if (_.has(latest, ["metadata"])) {
-		// We remove the name because depending on the type of resource we automatically rename the manifest and this
-		// should not be part of the diff
-		delete latestClone.metadata.name;
-		if (_.has(latest, ["metadata", "annotations"])) {
-			// All these annotations are dynamically generated and thus should not be diffed
-			delete latestClone.metadata.annotations[Annotations.OriginalName];
-			delete latestClone.metadata.annotations[Annotations.LastAppliedConfiguration];
-			delete latestClone.metadata.annotations[Annotations.LastAppliedConfigurationHash];
-			delete latestClone.metadata.annotations[Annotations.Commit];
+	if (_.has(latest, ["metadata", "annotations"])) {
+		// We want to use the original name before performing the diff (if one is found)
+		if (latestClone.metadata.annotations[Annotations.OriginalName]) {
+			latestClone.metadata.name = latestClone.metadata.annotations[Annotations.OriginalName];
+		}
+		// All these annotations are dynamically generated and thus should not be diffed
+		delete latestClone.metadata.annotations[Annotations.OriginalName];
+		delete latestClone.metadata.annotations[Annotations.LastAppliedConfiguration];
+		delete latestClone.metadata.annotations[Annotations.LastAppliedConfigurationHash];
+		delete latestClone.metadata.annotations[Annotations.Commit];
+		// If there are no other annotations remove the annotation block to prevent a false diff
+		if (Object.keys(latestClone.metadata.annotations).length == 0) {
+			delete latestClone.metadata.annotations;
 		}
 	}
 

--- a/test/unit/util/manifest-diff.spec.js
+++ b/test/unit/util/manifest-diff.spec.js
@@ -14,6 +14,7 @@ const scenarios = {
 		previous: {
 			enabled: true,
 			metadata: {
+				name: "the-original-name",
 				annotations: {
 					"keep-me": "okay"
 				}
@@ -22,11 +23,32 @@ const scenarios = {
 		latest: {
 			enabled: true,
 			metadata: {
-				name: "should-ignore-name",
+				name: "name-dynamically-modified",
 				annotations: {
 					"keep-me": "okay",
 					"kit-deployer/commit": "123abc",
-					"kit-deployer/original-name": "some-og-name",
+					"kit-deployer/original-name": "the-original-name",
+					"kit-deployer/last-applied-configuration": "last-applied-here",
+					"kit-deployer/last-applied-configuration-sha1": "sha1-here"
+				}
+			}
+		},
+		expected: undefined
+	},
+	"previous object with same properties but no annotations and latest with special annotations": {
+		previous: {
+			enabled: true,
+			metadata: {
+				name: "the-original-name"
+			}
+		},
+		latest: {
+			enabled: true,
+			metadata: {
+				name: "name-dynamically-modified",
+				annotations: {
+					"kit-deployer/commit": "123abc",
+					"kit-deployer/original-name": "the-original-name",
 					"kit-deployer/last-applied-configuration": "last-applied-here",
 					"kit-deployer/last-applied-configuration-sha1": "sha1-here"
 				}


### PR DESCRIPTION
# What

- the diff still wasn't quite right
- we need to diff against the original manifest name
- and we need to drop all annotations if the only annotations that exists were the ones we dynamically created

# Testing

1. Verified with unit test