### PR TITLE
Fixes #70

### DIFF
--- a/src/lib/health-check.js
+++ b/src/lib/health-check.js
@@ -36,6 +36,9 @@ class HealthCheck extends EventEmitter {
 	}
 
 	start(name) {
+		this.events.on("error", (err) => {
+			this.emit("error", err);
+		});
 		this.events.on("new", (event) => {
 			if (!_.has(event, ["type"])) {
 				return;


### PR DESCRIPTION
If KubectlEventWatcher had an error it emits an error event so we must listen
for it otherwise node throws an unhandled rejection error.