### PR TITLE
Fix: kubectl throwing emit error

### DIFF
--- a/src/lib/kubectl.js
+++ b/src/lib/kubectl.js
@@ -103,8 +103,9 @@ class KubectlEventWatcher extends EventEmitter {
 	}
 }
 
-class Kubectl {
+class Kubectl extends EventEmitter {
 	constructor(conf) {
+		super();
 		this.binary = conf.binary || "kubectl";
 
 		this.kubeconfig = conf.kubeconfig || "";

--- a/test/unit/lib/kubectl.spec.js
+++ b/test/unit/lib/kubectl.spec.js
@@ -1,0 +1,28 @@
+"use strict"
+
+const chai = require("chai");
+const expect = chai.expect;
+const Kubectl = require("../../../src/lib/kubectl");
+
+describe("Kubectl", () => {
+	describe("Constructor", () => {
+		it("should construct without error", () => {
+			const kubectl = new Kubectl({});
+			expect(kubectl).to.exist;
+		});
+	});
+	describe("Spawn", () => {
+		it("should emit spawn event", (done) => {
+			const kubectl = new Kubectl({});
+			kubectl.on("spawn", (args) => {
+				expect(args[0]).to.equal("help");
+				done();
+			});
+			kubectl.spawn(["help"]);
+		});
+		it("should run without error", (done) => {
+			const kubectl = new Kubectl({});
+			kubectl.spawn(["help"], done);
+		});
+	});
+});


### PR DESCRIPTION
Forgot to extend EventEmitter to allow for emitting events.

Added a simple unit test so I could verify `spawn` events are working and that I didn't break the `spawn` method. (sorry!)