### PR TITLE
allow a default strategy for the selector label

### DIFF
--- a/src/lib/annotator/annotator.js
+++ b/src/lib/annotator/annotator.js
@@ -119,9 +119,6 @@ class Annotator {
 		}
 
 		// Add strategy name label
-		if (!_.isUndefined(manifest.metadata.labels[Labels.Strategy])) {
-			throw new Error(`Reserved label ${Labels.Strategy} has been manually set`);
-		}
 		if (!_.isString(this.options.strategy.name)) {
 			throw new Error(`Requires string strategyName for reserved label ${Labels.Strategy}`);
 		}

--- a/test/unit/lib/annotator.spec.js
+++ b/test/unit/lib/annotator.spec.js
@@ -123,6 +123,14 @@ describe("Annotator", () => {
 				expect(manifest.metadata.annotations[Annotations.LastAppliedConfigurationHash]).to.equal("5fe441d20dd25a28df2c84667aa9e611df83a6c3");
 				expect(manifest.metadata.annotations[Annotations.Commit]).to.equal(JSON.stringify(options.sha));
 			});
+			it("should set the annotations with existing", () => {
+				let origManifest = _.cloneDeep(originalManifest);
+				origManifest.spec.selector.matchLabels.strategy = "some-update"
+				const manifest = annotator.annotate(_.cloneDeep(origManifest));
+				expect(manifest.metadata.name).to.equal(origManifest.metadata.name);
+				expect(manifest.spec.selector.matchLabels.strategy).to.equal(options.strategy.name);
+				expect(manifest.metadata.annotations[Annotations.LastAppliedConfiguration]).to.equal(JSON.stringify(origManifest));
+			});
 		});
 		describe("and calling annotate on job", () => {
 			it("should set the expected annotations", () => {


### PR DESCRIPTION
# What

We need to allow a base default strategy to be assigned to keep from initial deployments conflicting. Fixes #https://github.com/InVisionApp/engineering-velocity/issues/201 
along with 
https://github.com/InVisionApp/kubernetes-coreos/pull/2028

This PR should be merged before the coreos repo PR.