### PR TITLE
removing debug log with manifests

### DIFF
--- a/src/lib/elroy.js
+++ b/src/lib/elroy.js
@@ -165,7 +165,7 @@ class Elroy extends EventEmitter {
           this.emit(
             "warn",
             `Error updating ${this.options.clusterName}/${this.options
-              .resource} in Elroy: ${err.message}`
+              .resource} in Elroy to ${uri} : ${err.message}`
           );
           return reject(err);
         });

--- a/src/lib/elroy.js
+++ b/src/lib/elroy.js
@@ -167,12 +167,6 @@ class Elroy extends EventEmitter {
             `Error updating ${this.options.clusterName}/${this.options
               .resource} in Elroy: ${err.message}`
           );
-          const bodyStr = JSON.stringify(body);
-          this.emit(
-            "debug",
-            `Error updating ${this.options.clusterName}/${this.options
-              .resource} in Elroy to ${uri} with payload: ${bodyStr}`
-          );
           return reject(err);
         });
       return null;


### PR DESCRIPTION
https://github.com/InVisionApp/kit-server/issues/181 

As fas as I can see in loggly https://invisionmain.loggly.com/search#terms=%20json.kubernetes.container_name%3Akitserver-con%20test-rosie-v7&from=2017-08-28T10%3A30%3A12.324Z&until=2017-08-30T10%3A30%3A12.324Z&source_group= 

The problem is when we updating to elroy and there is an error, we emit a log debug with the entire body that contains the manifests. Let me know if  i missing something 