### PR TITLE
296 - Overwrite the UUID annotation when using a raw deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "chai": "3.5.0",
+    "chai-as-promised": "7.1.1",
     "mocha": "2.4.5",
     "sinon": "1.17.3",
     "sinon-chai": "2.8.0",

--- a/src/lib/annotator/annotator.js
+++ b/src/lib/annotator/annotator.js
@@ -43,6 +43,13 @@ class Annotator {
   annotate(manifest) {
     // Do not annotate if raw manifest given
     if (this.options.raw) {
+      // Initialize annotations object if it doesn't have one yet
+      if (!manifest.metadata) {
+        manifest.metadata = {};
+      }
+      if (!manifest.metadata.annotations) {
+        manifest.metadata.annotations = {};
+      }
       if (this.options.uuid) {
         manifest.metadata.annotations[Annotations.UUID] = this.options.uuid;
       }

--- a/src/lib/annotator/annotator.js
+++ b/src/lib/annotator/annotator.js
@@ -43,6 +43,9 @@ class Annotator {
   annotate(manifest) {
     // Do not annotate if raw manifest given
     if (this.options.raw) {
+      if (this.options.uuid) {
+        manifest.metadata.annotations[Annotations.UUID] = this.options.uuid;
+      }
       return manifest;
     }
 

--- a/src/lib/kubectl.js
+++ b/src/lib/kubectl.js
@@ -501,6 +501,20 @@ class Kubectl extends EventEmitter {
     });
   }
 
+  patch(kind, name, update) {
+    return new Promise((resolve, reject) => {
+      if (this.dryRun) {
+        return resolve(`DryRun is enabled: skipping kubectl.patch(${update})`);
+      }
+      this.spawn(["patch", kind, name, `-p ${update}`], (err, data) => {
+        if (err) {
+          return reject(err);
+        }
+        return resolve(data);
+      });
+    });
+  }
+
   recreate(filepath) {
     if (this.dryRun) {
       return Promise.resolve(

--- a/test/functional/fast-rollback.spec.js
+++ b/test/functional/fast-rollback.spec.js
@@ -749,6 +749,9 @@ describe("Functional fast-rollback", function() {
                 process.env.DEPLOY_ID
             );
             expect(stdout).to.contain(
+              `updating kit annotation on deployment nginx1-deployment-${id} to reference the current deploy uuid`
+            );
+            expect(stdout).to.contain(
               clusterName +
                 " - Strategy fast-rollback deployment nginx1-deployment-" +
                 id +
@@ -894,6 +897,9 @@ describe("Functional fast-rollback", function() {
               clusterName +
                 " - Running pre-deploy check to Apply nginx1-deployment-" +
                 process.env.DEPLOY_ID
+            );
+            expect(stdout).to.contain(
+              `updating kit annotation on deployment nginx1-deployment-${id} to reference the current deploy uuid`
             );
             expect(stdout).to.contain(
               clusterName +

--- a/test/unit/lib/annotator.spec.js
+++ b/test/unit/lib/annotator.spec.js
@@ -106,6 +106,68 @@ describe("Annotator", () => {
     });
   });
 
+  describe("Create New with a raw manifest", () => {
+    let annotator;
+    const rawManifest = {
+      kind: "Deployment",
+      metadata: {
+        name: "manifest-deployment",
+        annotations: {},
+        labels: {
+          name: "manifest-deployment"
+        }
+      },
+      spec: {
+        selector: {
+          matchLabels: {
+            name: "manifest-deployment"
+          }
+        }
+      }
+    };
+    rawManifest.metadata.annotations[Annotations.UUID] =
+      "d3bd6176-eb37-4ed7-b477-6a9075855cd5";
+
+    const rawJobManifest = {
+      kind: "Job",
+      metadata: {
+        name: "manifest-job",
+        annotations: {}
+      }
+    };
+    rawJobManifest.metadata.annotations[Annotations.UUID] =
+      "d3bd6176-eb37-4ed7-b477-6a9075855cd5";
+
+    const options = {
+      raw: true,
+      uuid: "dafbe5ac-f687-4b19-ba23-8fa91f84fbb8",
+      sha: "e05a1d976d3e5b5b42a4068b0f34be756cbd5f2a",
+      strategy: new Strategy(Strategies.RollingUpdate, {})
+    };
+    beforeEach(() => {
+      annotator = new Annotator(options);
+    });
+    it("should be cool with it", () => {
+      expect(annotator.options.sha).to.equal(options.sha);
+    });
+    describe("and calling annotate on deployment", () => {
+      it("should overwrite the UUID annotation", () => {
+        const manifest = annotator.annotate(_.cloneDeep(rawManifest));
+        expect(manifest.metadata.annotations[Annotations.UUID]).to.equal(
+          options.uuid
+        );
+      });
+    });
+    describe("and calling annotate on job", () => {
+      it("should overwrite the UUID annotation", () => {
+        const manifest = annotator.annotate(_.cloneDeep(rawJobManifest));
+        expect(manifest.metadata.annotations[Annotations.UUID]).to.equal(
+          options.uuid
+        );
+      });
+    });
+  });
+
   describe("Create New without UUID", () => {
     let annotator;
     const originalManifest = {


### PR DESCRIPTION
# What
This resolves the Elroy watcher issue for rollbacks via manifests by overwriting the uuid annotation when the manifest is raw.  Elroy uses this annotation so that it knows when the spec has been updated.

relates to #296
