### PR TITLE
EV-1299 - upgrading to the latest 1.8 variants of kubectl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:6.11.5-alpine
 
 # Defines the version of the kubectl binary
-ARG KUBE_VERSION=v1.6.4
+ARG KUBE_VERSION=v1.8.15
 
 # Add kubectl binary
 COPY scripts/download-kubectl.js scripts/download-kubectl.js

--- a/Functional-Dockerfile
+++ b/Functional-Dockerfile
@@ -1,7 +1,7 @@
 FROM node:6.11.5-alpine
 
 # Defines the version of the kubectl binary
-ARG KUBE_VERSION=v1.6.4
+ARG KUBE_VERSION=v1.8.15
 
 # Add kubectl binary
 COPY scripts/download-kubectl.js scripts/download-kubectl.js

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -13,7 +13,7 @@ test:
   cached: true
   entrypoint: npm run
   environment:
-    - KUBE_VERSION=v1.6.4
+    - KUBE_VERSION=v1.8.15
 publish:
   image: quay.io/invision/docker-node-publisher:v1
   encrypted_env_file: codeship-publish.env.encrypted
@@ -22,4 +22,4 @@ publish:
     - .:/var/publish
   environment:
     - PUBLISH_PATH=/var/publish
-    - KUBE_VERSION=v1.6.4
+    - KUBE_VERSION=v1.8.15


### PR DESCRIPTION
# What
- This addresses EV-1278 and is needed to support EV-1299.  kubectl version 1.6 doesn't work with kubernetes 1.8