### PR TITLE
Remove fake token used in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ var options = {
 	dryRun: true,
 	diff: true,
 	github: {
-		token: "ccd50691c75bc7bae0a5490ea08ff9dcc9c264a5",
+		token: "<OAUTH_TOKEN_HERE>",
 		user: "chesleybrown",
 		repo: "my-app"
 	}

--- a/in-repo.yaml
+++ b/in-repo.yaml
@@ -1,3 +1,4 @@
+visibility: public
 owner:
   active:
     team: engineering-velocity


### PR DESCRIPTION
This was not a real token, however we shouldn't have it in the readme regardless to avoid fears that it could have been a real token.

Verified by following directions [here](https://developer.github.com/v3/#authentication) and doing:

```
curl -H "Authorization: token ccd50691c75bc7bae0a5490ea08ff9dcc9c264a5" https://api.github.com
{
  "message": "Bad credentials",
  "documentation_url": "https://developer.github.com/v3"
}
```